### PR TITLE
Fix 'signup' type & Improve token issuing logic & Fix add menu logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    runtimeOnly("com.h2database:h2")
 
     // BCrypt Encoder (Spring Security 의존성 추가 없이 Encoder 사용할 때)
     implementation("at.favre.lib:bcrypt:0.10.2")

--- a/github/ci.yaml
+++ b/github/ci.yaml
@@ -1,0 +1,26 @@
+# 1. Workflow 이름 지정
+name: CI
+
+# 2. Workflow가 시작될 조건 지정
+on:
+  push:
+    branches: [main] # main 브랜치로 푸시할 때마다 Workflow 시작
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # 3. 실행 환경 지정
+    # 4. 실행 스텝 지정
+    steps:
+      - uses: actions/checkout@v3 # uses <- 지정한 리포지터리를 확인하고 코드에 대한 작업 실행
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew # name <- 스텝의 이름
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/src/main/java/com/threemeals/delivery/config/jwt/TokenProvider.java
+++ b/src/main/java/com/threemeals/delivery/config/jwt/TokenProvider.java
@@ -1,88 +1,123 @@
 package com.threemeals.delivery.config.jwt;
 
-import com.threemeals.delivery.domain.auth.exception.ExpiredTokenException;
-import com.threemeals.delivery.domain.auth.exception.InvalidTokenException;
-import com.threemeals.delivery.domain.user.entity.Role;
-import com.threemeals.delivery.domain.user.entity.User;
-import io.jsonwebtoken.*;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import static com.threemeals.delivery.config.util.Token.*;
 
 import java.time.Duration;
 import java.util.Date;
 
-import static com.threemeals.delivery.config.util.Token.BEARER_PREFIX;
+import org.springframework.stereotype.Service;
 
+import com.threemeals.delivery.domain.auth.exception.ExpiredTokenException;
+import com.threemeals.delivery.domain.auth.exception.InvalidTokenException;
+import com.threemeals.delivery.domain.user.entity.Role;
+import com.threemeals.delivery.domain.user.entity.User;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenProvider {
 
-    private final JwtProperties jwtProperties;
+	private final JwtProperties jwtProperties;
 
-    public String generateToken(User user, Duration validPeriod) {
-        Date now = new Date();
-        return makeToken(new Date(now.getTime() + validPeriod.toMillis()), user);
-    }
+	public String generateToken(User user, String tokenType, Duration validPeriod) {
 
-    private String makeToken(Date expiration, User user) {
-        return Jwts.builder()
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .setIssuer(jwtProperties.getIssuer())
-                .setIssuedAt(new Date())
-                .setExpiration(expiration)
-                .setSubject(user.getEmail()) // 토큰에 email 정보를 노출하는 건 좀 위험하지 않나... 크흠...
-                .claim("id", user.getId())
-                .claim("role", user.getRole())
-                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
-                .compact();
-    }
+		Date expiration = new Date(new Date().getTime() + validPeriod.toMillis());
 
-    public void validateToken(String rawToken) {
-        try {
-            String extractedToken = extractToken(rawToken);
-            Jwts.parser()
-                    .setSigningKey(jwtProperties.getSecretKey()) // 비밀키로 복호화
-                    .parseClaimsJws(extractedToken);
+		return tokenType.equals(ACCESS_TOKEN_TYPE) ?
+			makeAccessToken(expiration, user) : makeRefreshToken(expiration, user);
+	}
 
-        } catch (ExpiredJwtException e) {
-            throw new ExpiredTokenException();
-        } catch (Exception e) {
-            throw new InvalidTokenException();
-        }
-    }
+	private String makeAccessToken(Date expiration, User user) {
 
-    public Long getUserId(String token) {
-        Claims claims = getClaims(token);
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setIssuer(jwtProperties.getIssuer())
+			.setIssuedAt(new Date())
+			.setExpiration(expiration)
+			.setSubject(String.valueOf(user.getId()))
+			.claim("role", user.getRole()) // accessToken에만 Role 포함
+			.claim("tokenType", ACCESS_TOKEN_TYPE)
+			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+			.compact();
+	}
 
-        return claims.get("id", Long.class);
-    }
+	private String makeRefreshToken(Date expiration, User user) {
 
-    public Role getRole(String token) {
-        Claims claims = getClaims(token);
-        String role = claims.get("role", String.class);
+		return Jwts.builder()
+			.setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+			.setIssuer(jwtProperties.getIssuer())
+			.setIssuedAt(new Date())
+			.setExpiration(expiration)
+			.setSubject(String.valueOf(user.getId()))
+			.claim("tokenType", REFRESH_TOKEN_TYPE)
+			.signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+			.compact();
+	}
 
-        return Role.of(role);
-    }
+	public boolean isRefreshToken(String token) {
+		Claims claims = getClaims(token);
+		String tokenType = claims.get("tokenType", String.class);
 
-    private Claims getClaims(String token) {
-        String extractedToken = extractToken(token);
+		return tokenType.equals(REFRESH_TOKEN_TYPE);
+	}
 
-        // 여기서 isValidToken()을 한 번 더 사용해야 하나... 크흠...
-        return Jwts.parser()
-                .setSigningKey(jwtProperties.getSecretKey())
-                .parseClaimsJws(extractedToken)
-                .getBody();
-    }
+	public void validateToken(String rawToken) {
+		try {
+			String extractedToken = extractToken(rawToken);
+			Jwts.parser()
+				.setSigningKey(jwtProperties.getSecretKey()) // 비밀키로 복호화
+				.parseClaimsJws(extractedToken);
 
-    private String extractToken(String rawToken) { // "Bearer " 접두사 제거
+		} catch (ExpiredJwtException e) {
+			throw new ExpiredTokenException();
+		} catch (Exception e) {
+			throw new InvalidTokenException();
+		}
+	}
 
-        if (rawToken == null || rawToken.isBlank()) {
-            throw new InvalidTokenException();
-        }
+	public Long getUserId(String token) {
+		try { // 개인적으로 이런 try-catch는 좀 별로인 듯...
+			String subject = getClaims(token).getSubject();
+			return Long.valueOf(subject);
+		} catch (Exception e) {
+			throw new InvalidTokenException();
+		}
+	}
 
-        // Bearer 접두사가 없더라도 우선 허용.
-        return rawToken.startsWith(BEARER_PREFIX) ?
-                rawToken.substring(BEARER_PREFIX.length()) : rawToken;
-    }
+	public Role getRole(String token) {
+		Claims claims = getClaims(token);
+		String role = claims.get("role", String.class);
+
+		return Role.of(role);
+	}
+
+	private Claims getClaims(String token) {
+		String extractedToken = extractToken(token);
+
+		// 여기서 isValidToken()을 한 번 더 사용해야 하나... 크흠...
+		return Jwts.parser()
+			.setSigningKey(jwtProperties.getSecretKey())
+			.parseClaimsJws(extractedToken)
+			.getBody();
+	}
+
+	private String extractToken(String rawToken) { // "Bearer " 접두사 제거
+
+		if (rawToken == null || rawToken.isBlank()) {
+			throw new InvalidTokenException();
+		}
+
+		// Bearer 접두사가 없더라도 우선 허용.
+		return rawToken.startsWith(BEARER_PREFIX) ?
+			rawToken.substring(BEARER_PREFIX.length()) : rawToken;
+	}
+
 }

--- a/src/main/java/com/threemeals/delivery/config/util/Token.java
+++ b/src/main/java/com/threemeals/delivery/config/util/Token.java
@@ -6,6 +6,9 @@ public class Token {
 
     private Token() {}
 
+    public static final String ACCESS_TOKEN_TYPE = "access";
+    public static final String REFRESH_TOKEN_TYPE = "refresh";
+
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
 

--- a/src/main/java/com/threemeals/delivery/config/util/Url.java
+++ b/src/main/java/com/threemeals/delivery/config/util/Url.java
@@ -9,12 +9,9 @@ public class Url {
     }
 
     public static final String[] WHITE_LIST = {
-        "/signup", "/signup/**", "/login", "/users"
+        "/signup", "/signup/**", "/login", "/users", "/refresh-token"
 
     };
-
-    public static final String COOKIE_PATH = "/api";
-
 
     public static boolean isIncludedInWhiteList(String requestUrl) {
         return PatternMatchUtils.simpleMatch(WHITE_LIST, requestUrl);

--- a/src/main/java/com/threemeals/delivery/domain/auth/controller/AuthApiController.java
+++ b/src/main/java/com/threemeals/delivery/domain/auth/controller/AuthApiController.java
@@ -8,8 +8,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.threemeals.delivery.domain.auth.dto.request.LoginRequestDto;
 import com.threemeals.delivery.domain.auth.dto.request.SignupRequestDto;
+import com.threemeals.delivery.domain.auth.dto.request.UpdateTokenRequestDto;
 import com.threemeals.delivery.domain.auth.dto.response.LoginResponseDto;
 import com.threemeals.delivery.domain.auth.dto.response.SignupResponseDto;
+import com.threemeals.delivery.domain.auth.dto.response.UpdateTokenResponseDto;
 import com.threemeals.delivery.domain.auth.service.AuthService;
 
 import jakarta.validation.Valid;
@@ -21,9 +23,8 @@ public class AuthApiController {
 
 	private final AuthService authService;
 
-
 	@PostMapping("/signup")
-	public ResponseEntity<SignupResponseDto> singup(@Valid @RequestBody SignupRequestDto requestDto) {
+	public ResponseEntity<SignupResponseDto> signup(@Valid @RequestBody SignupRequestDto requestDto) {
 
 		SignupResponseDto response = authService.createUser(requestDto);
 		return ResponseEntity.status(HttpStatus.CREATED)
@@ -42,6 +43,13 @@ public class AuthApiController {
 	public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
 
 		LoginResponseDto response = authService.authenticate(requestDto);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/refresh-token")
+	public ResponseEntity<UpdateTokenResponseDto> createNewAccessToken(@Valid @RequestBody UpdateTokenRequestDto requestDto) {
+
+		UpdateTokenResponseDto response = authService.refreshAccessToken(requestDto.refreshToken());
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/threemeals/delivery/domain/auth/dto/request/UpdateTokenRequestDto.java
+++ b/src/main/java/com/threemeals/delivery/domain/auth/dto/request/UpdateTokenRequestDto.java
@@ -1,0 +1,9 @@
+package com.threemeals.delivery.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateTokenRequestDto(
+	@NotBlank(message = "토큰 값은 필수입니다")
+	String refreshToken
+) {
+}

--- a/src/main/java/com/threemeals/delivery/domain/auth/dto/response/UpdateTokenResponseDto.java
+++ b/src/main/java/com/threemeals/delivery/domain/auth/dto/response/UpdateTokenResponseDto.java
@@ -1,0 +1,4 @@
+package com.threemeals.delivery.domain.auth.dto.response;
+
+public record UpdateTokenResponseDto(String accessToken) {
+}

--- a/src/main/java/com/threemeals/delivery/domain/menu/controller/MenuApiController.java
+++ b/src/main/java/com/threemeals/delivery/domain/menu/controller/MenuApiController.java
@@ -49,10 +49,11 @@ public class MenuApiController {
 	@StoreOwnerOnly
 	@PostMapping("/menus")
 	public ResponseEntity<MenuResponseDto> addNewMenu(
+		@RequestParam Long storeId,
 		@Authentication UserPrincipal userPrincipal,
 		@Valid @RequestBody MenuRequestDto requestDto) {
 
-		MenuResponseDto response = menuService.addMenu(userPrincipal.getUserId(), requestDto);
+		MenuResponseDto response = menuService.addMenu(storeId, userPrincipal.getUserId(), requestDto);
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(response);
 	}

--- a/src/main/java/com/threemeals/delivery/domain/menu/repository/MenuRepositoryImpl.java
+++ b/src/main/java/com/threemeals/delivery/domain/menu/repository/MenuRepositoryImpl.java
@@ -14,7 +14,6 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.threemeals.delivery.domain.menu.dto.response.MenuResponseDto;
-import com.threemeals.delivery.domain.menu.entity.QMenuOption;
 
 import jakarta.persistence.EntityManager;
 
@@ -27,6 +26,7 @@ public class MenuRepositoryImpl implements MenuRepositoryForQueryDSL {
 	}
 
 	// Store 도메인에 해당 로직이 없고, 내가 직접 만들기에는 충돌 우려가 나서, 임시로 만듦
+	// 메뉴 삭제 여부 검증 X. 해당 메서드 호출 로직에서 해줌.
 	@Override
 	public boolean existsByMenuIdAndOwnerId(Long menuId, Long ownerId) {
 		return queryFactory

--- a/src/main/java/com/threemeals/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/threemeals/delivery/domain/user/entity/User.java
@@ -17,7 +17,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "user")
+@Table(name = "users")
 public class User extends BaseEntity {
 
 	@Id


### PR DESCRIPTION
* `signup` 메서드 오타 수정
* AccessToken, RefreshToken 발급 로직 및 토큰 페이로드 값을 조금 개선하였습니다.  기존에는 accessToken과 refreshToken이 만료 시간외에는 완전히 동일했는데, accessToken에만 role을 추가하고, refreshToken에는 role을 제거했습니다. 그렇기에 refreshToken으로는 API 통신이 불가합니다.
* 토큰에 subject를 email로 했는데, email을 노출하는 게 보안상 옳지 않은 거 같아서, subject에 userId 값을 넣어주고, 기존에 userId를 보관하는 'id' 필드를 제거했습니다. 
* menu를 추가할 때 API에 storeId를 명시적으로 받아오게 수정했습니다.